### PR TITLE
fix views gulp task

### DIFF
--- a/generators/app/templates/gulpfile.js
+++ b/generators/app/templates/gulpfile.js
@@ -92,7 +92,7 @@ gulp.task('nodemon', () => {
 });
 
 gulp.task('watch', () => {
-  gulp.watch(paths.html, ['html']);
+  gulp.watch(paths.views, ['views']);
   gulp.watch(paths.scripts, ['jshint', 'jscs']);
   gulp.watch(paths.styles, ['styles']);
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-galvanize-express",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Yeoman generator for a basic Node/Express app.",
   "homepage": "https://github.com/gSchool/generator-galvanize-express",
   "author": {


### PR DESCRIPTION
The `watch` task in the `gulpfile` was referencing a task called `html` which doesn't exist. Changed it to `views` to line up with the rest of the file.
