### PR TITLE
added cors middleware

### DIFF
--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -9,13 +9,14 @@
     "body-parser": "~1.15.1",
     "connect-flash": "^0.1.1",
     "cookie-parser": "~1.4.3",
+    "cors": "^2.8.1",
     "debug": "~2.2.0",
     "dotenv": "^2.0.0",
     "express": "~4.13.4",
     "express-session": "~1.14.0",
+    "knex": "~0.11.10",
     "morgan": "~1.7.0",
     "nunjucks": "~2.4.2",
-    "knex": "~0.11.10",
     "pg": "~6.1.0"
   },
   "devDependencies": {

--- a/generators/app/templates/src/server/config/main-config.js
+++ b/generators/app/templates/src/server/config/main-config.js
@@ -10,6 +10,7 @@
   const flash = require('connect-flash');
   const morgan = require('morgan');
   const nunjucks = require('nunjucks');
+  const cors = require('cors');
 
   // *** view folders *** //
   const viewFolders = [
@@ -32,6 +33,7 @@
     if (process.env.NODE_ENV !== 'test') {
       app.use(morgan('dev'));
     }
+    app.use(cors());
     app.use(cookieParser());
     app.use(bodyParser.json());
     app.use(bodyParser.urlencoded({ extended: false }));


### PR DESCRIPTION
For single route cors headers, comment out `app.use(cors())` in the main config, and add it as route specific middleware

i.e 

``` js
router.get('/products/:id', cors(), function(req, res, next){
  res.json({msg: 'This is CORS-enabled for a Single Route'});
});
```
