### PR TITLE
dont load .env in prod

### DIFF
--- a/generators/app/templates/src/server/config/main-config.js
+++ b/generators/app/templates/src/server/config/main-config.js
@@ -17,7 +17,9 @@
   ];
 
   // *** load environment variables *** //
-  require('dotenv').config();
+  if (process.env.NODE_ENV !== 'production') {
+    require('dotenv').config();
+  }
 
   appConfig.init = function(app, express) {
 


### PR DESCRIPTION
After doing Heroku deployment with students all day yesterday, it became clear that the boilerplate could use a conditional on loading `.env`, so that apps don't break on startup in production.